### PR TITLE
Added content getter to the Roa struct

### DIFF
--- a/src/roa.rs
+++ b/src/roa.rs
@@ -72,6 +72,11 @@ impl Roa {
     pub fn cert(&self) -> &Cert {
         self.signed.cert()
     }
+
+    /// Returns a reference to the RouteOriginAttestation content.
+    pub fn content(&self) -> &RouteOriginAttestation {
+        &self.content
+    }
 }
 
 


### PR DESCRIPTION
Self-explanatory. This small change is required by APNIC's Krill fork.